### PR TITLE
merge first and last name as formspree does not support

### DIFF
--- a/contact_us.html
+++ b/contact_us.html
@@ -33,17 +33,11 @@
 		<div class="flex justify-center">
 		<form class="w-full max-w-lg" name="input" accept-charset="utf-8" action="https://formspree.io/quantumcomputing@uci.edu" method="POST">
 			<div class="flex flex-wrap -mx-3 mb-6">
-				<div class="w-full md:w-1/2 px-3 mb-6 md:mb-0">
+				<div class="w-full px-3 mb-6 md:mb-0">
 					<label class="block uppercase tracking-wide text-gray-200 text-xs font-bold mb-2" for="grid-first-name">
-						First Name
+						Name
 					</label>
-					<input class="appearance-none block w-full bg-gray-200 text-gray-700 border rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white" id="grid-first-name" type="text" placeholder="Peter" name="name">
-				</div>
-				<div class="w-full md:w-1/2 px-3">
-					<label class="block uppercase tracking-wide text-gray-200 text-xs font-bold mb-2" for="grid-last-name">
-						Last Name
-					</label>
-					<input class="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-last-name" type="text" placeholder="Anteater">
+					<input class="appearance-none block w-full bg-gray-200 text-gray-700 border rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white" id="grid-first-name" type="text" placeholder="Peter Anteater" name="Name">
 				</div>
 			</div>
 			<div class="flex flex-wrap -mx-3 mb-6">


### PR DESCRIPTION
As we discussed @andyyPark, we should only leave one name field .

I haven't figured out why the box is a long bit longer with tailwind css. By disabling the boxSizing in tailwind config as shown [here](https://tailwindcss.com/docs/box-sizing) does not help. While I can spend more time trying to debug this I think maybe it more sense to leave it as this since we are gonna apply tailwind to all pages anyway and they should be consistent then.